### PR TITLE
le paramètre doit être vide

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -1,3 +1,3 @@
 {
-  "url":"http://mastercorpovannes.free.fr/new/etattarot.php"
+  "url":""
 }


### PR DESCRIPTION
Il faut laisser le paramètre vide, sauf si tu veux définir un paramètre par défaut (ce qui n'est pas le cas ici).

C'est dans le fichier `configuration.json` à la racine du programme qu'il faut entrer l'URL